### PR TITLE
feat: configure google sign in client

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,17 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+### Google Sign-In
+
+This project uses Google Sign-In for authentication. Before running the app,
+provide your OAuth **Web client ID** from the Firebase console so that a valid
+ID token can be returned. Pass it at build time using a Dart define:
+
+```bash
+flutter run --dart-define=GOOGLE_CLIENT_ID=your_client_id.apps.googleusercontent.com
+```
+
+Make sure the package name and SHA-1 fingerprint of your signing certificate
+are registered in the Firebase project and that the downloaded
+`google-services.json` contains the corresponding OAuth client entries.

--- a/lib/login_screen.dart
+++ b/lib/login_screen.dart
@@ -2,12 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 
+const String _webClientId = String.fromEnvironment('GOOGLE_CLIENT_ID');
+
 class LoginScreen extends StatelessWidget {
   const LoginScreen({super.key});
 
+  GoogleSignIn get _googleSignIn => GoogleSignIn(clientId: _webClientId.isEmpty ? null : _webClientId);
+
   Future<void> _signIn(BuildContext context) async {
     try {
-      final googleUser = await GoogleSignIn().signIn();
+      final googleUser = await _googleSignIn.signIn();
       if (googleUser == null) return;
       final googleAuth = await googleUser.authentication;
       final credential = GoogleAuthProvider.credential(


### PR DESCRIPTION
## Summary
- inject web client ID into Google Sign-In
- document Google Sign-In configuration

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f9233128832a8f80ec4618c95cfb