### PR TITLE
Fix popup arrow alignment on map

### DIFF
--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -1034,7 +1034,7 @@ class _MapScreenState extends State<MapScreen> {
           if (_selectedPlace != null && _infoWindowOffset != null)
             Positioned(
               left: _infoWindowOffset!.dx - 130,
-              top: _infoWindowOffset!.dy - 170,
+              top: _infoWindowOffset!.dy - 120,
               child: _buildPlacePopup(),
             ),
 


### PR DESCRIPTION
## Summary
- Reduce info window popup offset so arrow sits closer to the selected marker

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c53a2e4f28832aa16105230d0a6bd9