### PR TITLE
Move current location button to map overlay

### DIFF
--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -933,11 +933,6 @@ class _MapScreenState extends State<MapScreen> {
         title: const Text('Top Rated Places'),
         actions: [
           IconButton(
-            icon: const Icon(Icons.my_location),
-            tooltip: 'Về vị trí của tôi',
-            onPressed: _ensurePermissionAndLocate,
-          ),
-          IconButton(
             icon: const Icon(Icons.filter_list),
             tooltip: 'Bộ lọc',
             onPressed: _openFilterSheet,
@@ -1100,6 +1095,22 @@ class _MapScreenState extends State<MapScreen> {
                 ),
               ),
             ),
+
+          Positioned(
+            right: 16,
+            bottom: _top.isNotEmpty ? 140 : 16,
+            child: RawMaterialButton(
+              onPressed: _ensurePermissionAndLocate,
+              elevation: 4.0,
+              fillColor: Colors.white,
+              shape: const CircleBorder(),
+              constraints: const BoxConstraints.tightFor(
+                width: 48,
+                height: 48,
+              ),
+              child: const Icon(Icons.my_location, color: Colors.black87),
+            ),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- move current location control to floating button above map
- remove current location action from the top app bar
- enlarge current location button to match Google Maps

## Testing
- `dart format lib/screens/map_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c59fbc2e44832abb2fedcd47f39b77