### PR TITLE
style: add padding to search avatar

### DIFF
--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -1070,7 +1070,14 @@ class _MapScreenState extends State<MapScreen> {
                                 setState(() => _suggests = []);
                               },
                             ),
-                          _buildAccountButton(),
+                          Padding(
+                            padding: const EdgeInsets.only(
+                              right: 4,
+                              top: 4,
+                              bottom: 4,
+                            ),
+                            child: _buildAccountButton(),
+                          ),
                         ],
                       ),
                       suffixIconConstraints:


### PR DESCRIPTION
## Summary
- add padding to account avatar in map search box for even spacing

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a9ece2d4832a8f8f021b30e86fd3