### PR TITLE
fix: show logout menu below avatar

### DIFF
--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -1256,6 +1256,8 @@ class _MapScreenState extends State<MapScreen> {
       );
     }
     return PopupMenuButton<String>(
+      position: PopupMenuPosition.under,
+      offset: const Offset(0, 40),
       onSelected: (value) async {
         if (value == 'logout') {
           await FirebaseAuth.instance.signOut();


### PR DESCRIPTION
## Summary
- open logout popup below the avatar instead of covering it

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ad6b1190832aa48def2ad838956a