### PR TITLE
feat: make login optional

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,5 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
-
-import 'screens/login_screen.dart';
 import 'screens/map_screen.dart';
 
 Future<void> main() async {
@@ -19,20 +16,7 @@ class TopRatedPlacesApp extends StatelessWidget {
     return MaterialApp(
       title: 'Top Rated Places',
       theme: ThemeData(useMaterial3: true, colorSchemeSeed: Colors.blue),
-      home: StreamBuilder<User?>(
-        stream: FirebaseAuth.instance.authStateChanges(),
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Scaffold(
-              body: Center(child: CircularProgressIndicator()),
-            );
-          }
-          if (snapshot.hasData) {
-            return const MapScreen();
-          }
-          return const LoginScreen();
-        },
-      ),
+      home: const MapScreen(),
       debugShowCheckedModeBanner: false,
     );
   }

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -1244,15 +1244,16 @@ class _MapScreenState extends State<MapScreen> {
   Widget _buildAccountButton() {
     final user = FirebaseAuth.instance.currentUser;
     if (user == null) {
-      return IconButton(
-        icon: const Icon(Icons.login),
-        tooltip: 'Đăng nhập',
-        onPressed: () {
+      return GestureDetector(
+        onTap: () {
           Navigator.push(
             context,
             MaterialPageRoute(builder: (_) => const LoginScreen()),
           ).then((_) => setState(() {}));
         },
+        child: const CircleAvatar(
+          child: Icon(Icons.person_outline),
+        ),
       );
     }
     return PopupMenuButton<String>(


### PR DESCRIPTION
## Summary
- Launch straight into map without requiring authentication
- Show placeholder avatar when not logged in and open login on tap

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5aea2ac98832ab2d726bb609355b0