### PR TITLE
Disable filter SnackBar when centering on current location

### DIFF
--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -411,7 +411,7 @@ class _MapScreenState extends State<MapScreen> {
         .toList();
   }
 
-  Future<void> _fetchAndShow() async {
+  Future<void> _fetchAndShow({bool notify = false}) async {
     if (_current == null) return;
     setState(() => _loading = true);
 
@@ -520,7 +520,7 @@ class _MapScreenState extends State<MapScreen> {
         _markers = newMarkers;
       });
 
-      if (mounted) {
+      if (notify && mounted) {
         final catCount = cats.length;
         final total = top.length;
         ScaffoldMessenger.of(context).showSnackBar(
@@ -954,7 +954,7 @@ class _MapScreenState extends State<MapScreen> {
                               });
                               _renderSearchMarkerAndCircle();
                               Navigator.pop(context);
-                              _fetchAndShow();
+                              _fetchAndShow(notify: true);
                             },
                             child: const Text('Đặt lại'),
                           ),
@@ -988,7 +988,7 @@ class _MapScreenState extends State<MapScreen> {
                                 });
                                 _renderSearchMarkerAndCircle();
                                 Navigator.pop(context);
-                                _fetchAndShow();
+                                _fetchAndShow(notify: true);
                               },
                               child: const Text('Áp dụng bộ lọc'),
                             ),


### PR DESCRIPTION
## Summary
- add optional `notify` flag to `_fetchAndShow` so SnackBars only appear when explicitly requested
- request notifications only when filter settings change

## Testing
- `dart format lib/screens/map_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b09921d0832a8b421e9565124bcf