### PR TITLE
fix: keep digits in custom radius input

### DIFF
--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
@@ -841,6 +842,9 @@ class _MapScreenState extends State<MapScreen> {
                           child: TextField(
                             controller: _radiusCustomCtl,
                             keyboardType: TextInputType.number,
+                            inputFormatters: [
+                              FilteringTextInputFormatter.digitsOnly,
+                            ],
                             decoration: const InputDecoration(
                               hintText: 'km',
                               isDense: true,


### PR DESCRIPTION
## Summary
- allow only digit characters in custom radius field to prevent disappearing input
- add necessary services import

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c67ca31ab8832ab40f10fa97dc5152